### PR TITLE
Fix booking slot disabling per equipment

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -34,7 +34,7 @@ interface UserHistory {
 }
 
 interface Booking {
-  id: number
+  id: string
   user: string
   userEmail: string
   department: string
@@ -127,7 +127,16 @@ export default function AdminDashboardPage() {
       mapped.forEach((b) => {
         if (!slots[b.equipmentId]) slots[b.equipmentId] = {};
         if (!slots[b.equipmentId][b.date]) slots[b.equipmentId][b.date] = [];
-        slots[b.equipmentId][b.date].push(b.startTime);
+
+        // push the start time and subsequent slots based on duration
+        const [startHour] = b.startTime.split(":").map(Number);
+        for (let i = 0; i < Math.ceil(b.duration); i++) {
+          const slotHour = startHour + i;
+          const slot = `${slotHour.toString().padStart(2, "0")}:00`;
+          if (!slots[b.equipmentId][b.date].includes(slot)) {
+            slots[b.equipmentId][b.date].push(slot);
+          }
+        }
       });
       setBookedSlotsByDate(slots);
 
@@ -214,7 +223,15 @@ export default function AdminDashboardPage() {
       mapped.forEach((b: any) => {
         if (!slots[b.equipmentId]) slots[b.equipmentId] = {};
         if (!slots[b.equipmentId][b.date]) slots[b.equipmentId][b.date] = [];
-        slots[b.equipmentId][b.date].push(b.startTime);
+
+        const [startHour] = b.startTime.split(":").map(Number);
+        for (let i = 0; i < Math.ceil(b.duration); i++) {
+          const slotHour = startHour + i;
+          const slot = `${slotHour.toString().padStart(2, "0")}:00`;
+          if (!slots[b.equipmentId][b.date].includes(slot)) {
+            slots[b.equipmentId][b.date].push(slot);
+          }
+        }
       });
       setBookedSlotsByDate(slots);
 

--- a/app/api/booking/route.ts
+++ b/app/api/booking/route.ts
@@ -47,8 +47,9 @@ export async function GET(req: Request) {
           status:     b.status,
           createdAt:  b.createdAt,
           userEmail:  b.userEmail,
-          equipment:  b.equipmentId.name,
-          userName:   user?.name ?? 'Unknown'
+          equipment:   b.equipmentId.name,
+          equipmentId: (b.equipmentId as any)._id?.toString() ?? '',
+          userName:    user?.name ?? 'Unknown'
         }
       })
     )


### PR DESCRIPTION
## Summary
- include `equipmentId` in booking API responses
- track all occupied slots per equipment while considering booking duration
- update admin dashboard data types

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_684a470b7288832f91af925398f630b8