### PR TITLE
Implement admin management on super admin page

### DIFF
--- a/app/api/admin/route.ts
+++ b/app/api/admin/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server"
+import { dbConnect } from "@/lib/db"
+import Admin from "@/models/Admin"
+import User from "@/models/User"
+
+// GET /api/admin
+export async function GET() {
+  await dbConnect()
+  const admins = await Admin.find({})
+    .populate<{ _id: string; name: string }>("assignedInstruments", "name")
+    .lean()
+
+  const result = await Promise.all(
+    admins.map(async (admin: any) => {
+      const user = await User.findOne({ email: admin.email }, "name department").lean()
+      return {
+        id: admin._id.toString(),
+        email: admin.email,
+        name: user?.name || "",
+        department: user?.department || "",
+        instruments: (admin.assignedInstruments || []).map((eq: any) => ({
+          id: eq._id.toString(),
+          name: eq.name,
+        })),
+      }
+    })
+  )
+
+  return NextResponse.json(result)
+}
+
+// POST /api/admin
+export async function POST(req: Request) {
+  await dbConnect()
+  const { email, assignedInstruments } = await req.json()
+
+  if (!email) {
+    return NextResponse.json({ error: "Email required" }, { status: 400 })
+  }
+
+  const existing = await Admin.findOne({ email })
+  if (existing) {
+    return NextResponse.json({ error: "Admin already exists" }, { status: 409 })
+  }
+
+  const admin = await Admin.create({
+    email,
+    assignedInstruments: assignedInstruments || [],
+  })
+
+  return NextResponse.json(admin, { status: 201 })
+}


### PR DESCRIPTION
## Summary
- create `/api/admin` API to fetch and create admins
- display real admin count on dashboard
- allow searching admins and adding new admin assignments
- fetch admins from backend and show equipment admins

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684a52b7b478832fb7f87d8071115dfd