### PR TITLE
Implement admin access management

### DIFF
--- a/app/api/admin/[id]/route.ts
+++ b/app/api/admin/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server"
+import { dbConnect } from "@/lib/db"
+import Admin from "@/models/Admin"
+
+interface Params { params: { id: string } }
+
+export async function PATCH(req: Request, { params }: Params) {
+  await dbConnect()
+  const { assignedInstruments } = await req.json()
+  try {
+    const updated = await Admin.findByIdAndUpdate(
+      params.id,
+      { assignedInstruments: assignedInstruments || [] },
+      { new: true }
+    )
+    if (!updated) {
+      return NextResponse.json({ error: "Admin not found" }, { status: 404 })
+    }
+    return NextResponse.json(updated, { status: 200 })
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message || "Failed" }, { status: 400 })
+  }
+}

--- a/app/api/admin/route.ts
+++ b/app/api/admin/route.ts
@@ -43,10 +43,20 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Admin already exists" }, { status: 409 })
   }
 
+  const user = await User.findOne({ email })
+  if (!user) {
+    return NextResponse.json({ error: "User not found" }, { status: 404 })
+  }
+
   const admin = await Admin.create({
     email,
     assignedInstruments: assignedInstruments || [],
   })
+
+  if (user.role !== "Super-admin" && user.role !== "admin") {
+    user.role = "admin"
+    await user.save()
+  }
 
   return NextResponse.json(admin, { status: 201 })
 }

--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server"
+import { dbConnect } from "@/lib/db"
+import User from "@/models/User"
+
+export async function GET(req: Request) {
+  await dbConnect()
+  const { searchParams } = new URL(req.url)
+  const search = searchParams.get("search") || ""
+  const filter = search
+    ? { email: { $regex: search, $options: "i" } }
+    : {}
+  const users = await User.find(filter).limit(10).lean()
+  const result = users.map((u) => ({
+    id: u._id.toString(),
+    name: u.name,
+    email: u.email,
+    department: u.department,
+    role: u.role,
+  }))
+  return NextResponse.json(result)
+}


### PR DESCRIPTION
## Summary
- extend admin API to update user role when added
- add endpoint for filtering users by email
- allow updating an admin's assigned instruments
- expose manage access dialog on super admin page
- support dynamic email search when adding admins

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a640271f8832f87967ee11598b749