### PR TITLE
Filter admin bookings by assigned instruments

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -62,11 +62,8 @@ interface EquipmentInfo {
 }
 
 
-const assignedInstruments: Instrument[] = [
-  { id: 2, name: "Confocal Microscope" },
-]
 interface Instrument {
-  id: number
+  id: string
   name: string
 }
 
@@ -87,13 +84,14 @@ export default function AdminDashboardPage() {
   const [equipmentStats, setEquipmentStats] = useState<EquipmentInfo[]>([])
   const [bookedSlotsByDate, setBookedSlotsByDate] = useState<{ [equipmentId: string]: { [date: string]: string[] } }>({});
   const [slotLoading, setSlotLoading] = useState(false);
+  const [assignedInstruments, setAssignedInstruments] = useState<Instrument[]>([]);
 
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
   setLoading(true);
   Promise.all([
-    fetch("/api/booking").then((res) => res.json()),
+    fetch("/api/admin/bookings").then((res) => res.json()),
     fetch("/api/equipment").then((res) => res.json()),
   ])
     .then(([bookings, equipmentList]: [any[], any[]]) => {
@@ -121,6 +119,14 @@ export default function AdminDashboardPage() {
 
       setAllBookings(mapped);
       setpendingBookings(mapped.filter((b) => b.status === "pending"));
+
+      const uniqueMap = new Map<string, string>();
+      mapped.forEach((b) => {
+        if (!uniqueMap.has(b.equipmentId)) {
+          uniqueMap.set(b.equipmentId, b.equipment);
+        }
+      });
+      setAssignedInstruments(Array.from(uniqueMap, ([id, name]) => ({ id, name })));
 
       // Collect all booked slots by equipmentId and date
       const slots: { [equipmentId: string]: { [date: string]: string[] } } = {};
@@ -187,7 +193,7 @@ export default function AdminDashboardPage() {
     setLoading(true);
     try {
       const [bookingsRes, equipmentRes] = await Promise.all([
-        fetch("/api/booking"),
+        fetch("/api/admin/bookings"),
         fetch("/api/equipment"),
       ]);
       const bookings = await bookingsRes.json();
@@ -217,6 +223,14 @@ export default function AdminDashboardPage() {
 
       setAllBookings(mapped);
       setpendingBookings(mapped.filter((b: any) => b.status === "pending"));
+
+      const uniqueMap = new Map<string, string>();
+      mapped.forEach((b: any) => {
+        if (!uniqueMap.has(b.equipmentId)) {
+          uniqueMap.set(b.equipmentId, b.equipment);
+        }
+      });
+      setAssignedInstruments(Array.from(uniqueMap, ([id, name]) => ({ id, name })));
 
       // Collect all booked slots by equipmentId and date
       const slots: { [equipmentId: string]: { [date: string]: string[] } } = {};

--- a/app/api/admin/bookings/route.ts
+++ b/app/api/admin/bookings/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { dbConnect } from "@/lib/db";
+import Booking from "@/models/Booking";
+import Equipment from "@/models/Equipment";
+import User from "@/models/User";
+import Admin from "@/models/Admin";
+import jwt from "jsonwebtoken";
+import { Types } from "mongoose";
+
+interface LeanBooking {
+  _id: Types.ObjectId;
+  userEmail: string;
+  equipmentId: { _id: Types.ObjectId; name: string };
+  date: string;
+  startTime: string;
+  duration: number;
+  supervisor: string;
+  department: string;
+  purpose: string;
+  status: 'pending' | 'approved' | 'rejected';
+  createdAt: Date;
+}
+
+export async function GET() {
+  await dbConnect();
+
+  const cookieStore = cookies();
+  const token = cookieStore.get("token")?.value;
+  if (!token) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const payload = jwt.verify(token, process.env.JWT_SECRET!);
+    const email = (payload as any).email as string;
+    if (!email) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
+    const admin = await Admin.findOne({ email }).lean<{ assignedInstruments: Types.ObjectId[] }>();
+    if (!admin) {
+      return NextResponse.json([], { status: 200 });
+    }
+
+    const bookingsRaw = await Booking.find({ equipmentId: { $in: admin.assignedInstruments } })
+      .populate<{ equipmentId: { _id: Types.ObjectId; name: string } }>("equipmentId", "name")
+      .sort({ date: -1 })
+      .lean<LeanBooking[]>();
+
+    const bookings = await Promise.all(
+      bookingsRaw.map(async (b) => {
+        const user = await User.findOne({ email: b.userEmail }, "name").lean<{ name: string }>();
+        return {
+          id: b._id.toString(),
+          date: b.date,
+          startTime: b.startTime,
+          duration: b.duration,
+          supervisor: b.supervisor,
+          department: b.department,
+          purpose: b.purpose,
+          status: b.status,
+          createdAt: b.createdAt,
+          userEmail: b.userEmail,
+          equipment: b.equipmentId.name,
+          equipmentId: (b.equipmentId as any)._id?.toString() ?? '',
+          userName: user?.name ?? 'Unknown',
+        };
+      })
+    );
+
+    return NextResponse.json(bookings);
+  } catch (err: any) {
+    console.error(err);
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary
- add API route `/api/admin/bookings` that returns only bookings for the logged‑in admin's assigned instruments
- update admin dashboard to fetch from the new endpoint
- track admin's assigned instrument list dynamically from returned bookings

## Testing
- `npm run lint` *(fails: awaiting interactive configuration)*
- `npm run build` *(fails to fetch fonts during Next.js build)*

------
https://chatgpt.com/codex/tasks/task_e_684afd13a348832f852a40ed125e1eaf