### PR TITLE
Update slot disable logic

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -131,6 +131,7 @@ export default function AdminDashboardPage() {
       // Collect all booked slots by equipmentId and date
       const slots: { [equipmentId: string]: { [date: string]: string[] } } = {};
       mapped.forEach((b) => {
+        if (b.status !== "approved") return;
         if (!slots[b.equipmentId]) slots[b.equipmentId] = {};
         if (!slots[b.equipmentId][b.date]) slots[b.equipmentId][b.date] = [];
 
@@ -235,6 +236,7 @@ export default function AdminDashboardPage() {
       // Collect all booked slots by equipmentId and date
       const slots: { [equipmentId: string]: { [date: string]: string[] } } = {};
       mapped.forEach((b: any) => {
+        if (b.status !== "approved") return;
         if (!slots[b.equipmentId]) slots[b.equipmentId] = {};
         if (!slots[b.equipmentId][b.date]) slots[b.equipmentId][b.date] = [];
 


### PR DESCRIPTION
## Summary
- disable start times if an approved booking already occupies the slot

## Testing
- `npm run lint` *(fails: requires interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684eb42b6944832f948c582288bc3f30