### PR TITLE
Auto-complete bookings

### DIFF
--- a/app/api/admin/bookings/route.ts
+++ b/app/api/admin/bookings/route.ts
@@ -5,6 +5,7 @@ import Booking from "@/models/Booking";
 import Equipment from "@/models/Equipment";
 import User from "@/models/User";
 import Admin from "@/models/Admin";
+import { autoCompleteBookings } from "@/lib/bookingUtils";
 import jwt from "jsonwebtoken";
 import { Types } from "mongoose";
 
@@ -18,12 +19,13 @@ interface LeanBooking {
   supervisor: string;
   department: string;
   purpose: string;
-  status: 'pending' | 'approved' | 'rejected';
+  status: 'pending' | 'approved' | 'rejected' | 'completed';
   createdAt: Date;
 }
 
 export async function GET() {
   await dbConnect();
+  await autoCompleteBookings();
 
   const cookieStore = cookies();
   const token = cookieStore.get("token")?.value;

--- a/app/api/booking/[id]/route.ts
+++ b/app/api/booking/[id]/route.ts
@@ -3,11 +3,13 @@
 import { NextResponse } from "next/server";
 import { dbConnect } from "@/lib/db";
 import Booking from "@/models/Booking";
+import { autoCompleteBookings } from "@/lib/bookingUtils";
 
 type Params = { params: { id: string } };
 
 export async function GET(request: Request, { params }: Params) {
   await dbConnect();
+  await autoCompleteBookings();
   try {
     const booking = await Booking
       .findById(params.id)

--- a/app/api/booking/route.ts
+++ b/app/api/booking/route.ts
@@ -3,6 +3,7 @@ import { dbConnect } from '@/lib/db'
 import Booking from '@/models/Booking'
 import Equipment from '@/models/Equipment'
 import User from '@/models/User'
+import { autoCompleteBookings } from '@/lib/bookingUtils'
 import { Types } from 'mongoose'
 
 interface LeanBooking {
@@ -15,12 +16,13 @@ interface LeanBooking {
   supervisor:  string
   department:  string
   purpose:     string
-  status:      'pending' | 'approved' | 'rejected'
+  status:      'pending' | 'approved' | 'rejected' | 'completed'
   createdAt:   Date
 }
 
 export async function GET(req: Request) {
   await dbConnect()
+  await autoCompleteBookings()
 
   try {
     const raw = await Booking.find({})

--- a/lib/bookingUtils.ts
+++ b/lib/bookingUtils.ts
@@ -1,0 +1,16 @@
+export async function autoCompleteBookings() {
+  const Booking = (await import('@/models/Booking')).default
+  const now = new Date()
+  const approved = await Booking.find({ status: 'approved' })
+  for (const b of approved) {
+    const [hourStr, minuteStr] = (b.startTime || '0:0').split(':')
+    const start = new Date(`${b.date}T00:00`)
+    start.setHours(parseInt(hourStr, 10))
+    start.setMinutes(parseInt(minuteStr, 10))
+    const end = new Date(start.getTime() + (b.duration || 0) * 60 * 60 * 1000)
+    if (now >= end) {
+      b.status = 'completed'
+      await b.save()
+    }
+  }
+}

--- a/models/Booking.ts
+++ b/models/Booking.ts
@@ -9,7 +9,11 @@ const BookingSchema = new Schema({
   supervisor: { type: String},
   department: { type: String},
   purpose: { type: String},
-  status: { type: String, enum: ['pending', 'approved', 'rejected'], default: 'pending' },
+  status: {
+    type: String,
+    enum: ['pending', 'approved', 'rejected', 'completed'],
+    default: 'pending',
+  },
   createdAt: { type: Date, default: Date.now },
 })
 


### PR DESCRIPTION
## Summary
- update Booking model to include `completed` status
- add `autoCompleteBookings` helper to mark past approved bookings as completed
- invoke helper in booking-related API routes

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npx tsc --noEmit` *(fails: type errors)*
- `npm run build` *(fails: blocked network requests)*

------
https://chatgpt.com/codex/tasks/task_e_684eb4f2aa1c832fbd5a033e40d5d78b