### PR TITLE
Improve booking history priority

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -31,6 +31,7 @@ interface UserHistory {
   date: string
   equipment: string
   status: string
+  timeSlot: string
 }
 
 interface Booking {
@@ -46,6 +47,7 @@ interface Booking {
   duration: number
   purpose: string
   userHistory: UserHistory[]
+  lastUsed?: string | null
   status?: string
   reason?: string
 }
@@ -113,8 +115,9 @@ export default function AdminDashboardPage() {
           duration:     b.duration,
           purpose:      b.purpose,
           status:       b.status,
-          userHistory:  [],
-        }
+          userHistory:  b.userHistory ?? [],
+          lastUsed:     b.lastUsed ?? null,
+        };
       });
 
       setAllBookings(mapped);
@@ -217,8 +220,9 @@ export default function AdminDashboardPage() {
           duration:     b.duration,
           purpose:      b.purpose,
           status:       b.status,
-          userHistory:  [],
-        }
+          userHistory:  b.userHistory ?? [],
+          lastUsed:     b.lastUsed ?? null,
+        };
       });
 
       setAllBookings(mapped);
@@ -674,6 +678,11 @@ export default function AdminDashboardPage() {
                                 View
                               </Button>
                             )}
+                            {booking.lastUsed && (
+                              <span className="text-xs ml-2 text-gray-500">
+                                Last used on {new Date(booking.lastUsed).toLocaleDateString()}
+                              </span>
+                            )}
                           </div>
                         </CardContent>
                         <CardFooter className="flex justify-end gap-2">
@@ -1016,6 +1025,7 @@ export default function AdminDashboardPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead>Date</TableHead>
+                  <TableHead>Time Slot</TableHead>
                   <TableHead>Equipment</TableHead>
                   <TableHead>Status</TableHead>
                 </TableRow>
@@ -1024,6 +1034,7 @@ export default function AdminDashboardPage() {
                 {selectedBooking?.userHistory.map((history, index) => (
                   <TableRow key={index}>
                     <TableCell>{new Date(history.date).toLocaleDateString()}</TableCell>
+                    <TableCell>{history.timeSlot}</TableCell>
                     <TableCell>{history.equipment}</TableCell>
                     <TableCell>
                       <Badge
@@ -1042,7 +1053,7 @@ export default function AdminDashboardPage() {
                 ))}
                 {selectedBooking?.userHistory.length === 0 && (
                   <TableRow>
-                    <TableCell colSpan={3} className="text-center py-4 text-gray-500">
+                    <TableCell colSpan={4} className="text-center py-4 text-gray-500">
                       No booking history found
                     </TableCell>
                   </TableRow>

--- a/app/api/admin/bookings/route.ts
+++ b/app/api/admin/bookings/route.ts
@@ -2,7 +2,6 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { dbConnect } from "@/lib/db";
 import Booking from "@/models/Booking";
-import Equipment from "@/models/Equipment";
 import User from "@/models/User";
 import Admin from "@/models/Admin";
 import jwt from "jsonwebtoken";
@@ -43,14 +42,48 @@ export async function GET() {
       return NextResponse.json([], { status: 200 });
     }
 
-    const bookingsRaw = await Booking.find({ equipmentId: { $in: admin.assignedInstruments } })
-      .populate<{ equipmentId: { _id: Types.ObjectId; name: string } }>("equipmentId", "name")
+    const bookingsRaw = await Booking.find({
+      equipmentId: { $in: admin.assignedInstruments },
+    })
+      .populate<{ equipmentId: { _id: Types.ObjectId; name: string } }>(
+        "equipmentId",
+        "name",
+      )
       .sort({ date: -1 })
       .lean<LeanBooking[]>();
 
     const bookings = await Promise.all(
       bookingsRaw.map(async (b) => {
-        const user = await User.findOne({ email: b.userEmail }, "name").lean<{ name: string }>();
+        const user = await User.findOne({ email: b.userEmail }, "name").lean<{
+          name: string;
+        }>();
+
+        const historyRaw = await Booking.find({
+          equipmentId: (b.equipmentId as any)._id ?? b.equipmentId,
+          userEmail: b.userEmail,
+          _id: { $ne: b._id },
+        })
+          .sort({ date: -1, startTime: -1 })
+          .lean<{
+            date: string;
+            startTime: string;
+            duration: number;
+            status: string;
+          }[]>();
+
+        const userHistory = historyRaw.map((h) => {
+          const [startHour] = h.startTime.split(":").map(Number);
+          const endHour = startHour + h.duration;
+          return {
+            date: h.date,
+            equipment: b.equipmentId.name,
+            status: h.status,
+            timeSlot: `${h.startTime} - ${endHour.toString().padStart(2, "0")}:00`,
+          };
+        });
+
+        const lastUsed = historyRaw[0]?.date ?? null;
+
         return {
           id: b._id.toString(),
           date: b.date,
@@ -64,10 +97,18 @@ export async function GET() {
           userEmail: b.userEmail,
           equipment: b.equipmentId.name,
           equipmentId: (b.equipmentId as any)._id?.toString() ?? '',
-          userName: user?.name ?? 'Unknown',
+          userName: user?.name ?? "Unknown",
+          userHistory,
+          lastUsed,
         };
       })
     );
+
+    bookings.sort((a, b) => {
+      const dateA = a.lastUsed ? new Date(a.lastUsed).getTime() : 0;
+      const dateB = b.lastUsed ? new Date(b.lastUsed).getTime() : 0;
+      return dateA - dateB;
+    });
 
     return NextResponse.json(bookings);
   } catch (err: any) {


### PR DESCRIPTION
## Summary
- track a user's past bookings for the same equipment when fetching admin bookings
- sort pending bookings by least recent user usage
- display the last used date on each pending booking card
- show detailed booking history with time slots in history dialog

## Testing
- `npm run lint` *(fails: prompts for setup)*
- `npm test` *(fails: missing script)*
- `npx tsc -p tsconfig.json` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ebe9fcf14832f9cf868a80c38cd9a