### PR TITLE
Show user initials in avatar fallback

### DIFF
--- a/components/user-nav.tsx
+++ b/components/user-nav.tsx
@@ -75,7 +75,16 @@ export function UserNav() {
       <Button variant="ghost" className="relative h-8 w-8 rounded-full">
         <Avatar className="h-8 w-8">
         <AvatarImage src="/images/user.png" alt="User" />
-        <AvatarFallback>US</AvatarFallback>
+        <AvatarFallback>
+          {userData?.name
+            ? userData.name
+                .split(" ")
+                .map((n) => n.charAt(0))
+                .join("")
+                .slice(0, 2)
+                .toUpperCase()
+            : "US"}
+        </AvatarFallback>
         </Avatar>
       </Button>
       </DropdownMenuTrigger>


### PR DESCRIPTION
## Summary
- update the user navigation avatar fallback to display the logged-in user's initials

## Testing
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run build` *(fails: unable to fetch fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6857bbc0d940832f9238035b3545e3a7