### PR TITLE
Enable equipment deletion

### DIFF
--- a/app/api/equipment/[id]/route.ts
+++ b/app/api/equipment/[id]/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server"
+import { dbConnect } from "@/lib/db"
+import Equipment from "@/models/Equipment"
+
+interface Params { params: { id: string } }
+
+export async function GET(req: Request, { params }: Params) {
+  await dbConnect()
+  try {
+    const eq = await Equipment.findById(params.id)
+    if (!eq) {
+      return NextResponse.json({ error: "Equipment not found" }, { status: 404 })
+    }
+    return NextResponse.json(eq, { status: 200 })
+  } catch (err) {
+    return NextResponse.json({ error: "Invalid equipment ID" }, { status: 400 })
+  }
+}
+
+export async function PATCH(req: Request, { params }: Params) {
+  await dbConnect()
+  let data: any
+  try {
+    data = await req.json()
+  } catch (err) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+  try {
+    const updated = await Equipment.findByIdAndUpdate(params.id, data, { new: true })
+    if (!updated) {
+      return NextResponse.json({ error: "Equipment not found" }, { status: 404 })
+    }
+    return NextResponse.json(updated, { status: 200 })
+  } catch (err: any) {
+    return NextResponse.json({ error: err.message || "Failed to update" }, { status: 400 })
+  }
+}
+
+export async function DELETE(req: Request, { params }: Params) {
+  await dbConnect()
+  try {
+    const deleted = await Equipment.findByIdAndDelete(params.id)
+    if (!deleted) {
+      return NextResponse.json({ error: "Equipment not found" }, { status: 404 })
+    }
+    return NextResponse.json({ message: "Equipment deleted" }, { status: 200 })
+  } catch (err) {
+    return NextResponse.json({ error: "Failed to delete equipment" }, { status: 400 })
+  }
+}
+

--- a/app/super-admin/dashboard/page.tsx
+++ b/app/super-admin/dashboard/page.tsx
@@ -307,6 +307,19 @@ export default function SuperAdminDashboardPage() {
     }
   }
 
+  const handleDeleteEquipment = async (id: string) => {
+    if (!confirm("Are you sure you want to delete this equipment?")) {
+      return
+    }
+    try {
+      const res = await fetch(`/api/equipment/${id}`, { method: "DELETE" })
+      if (!res.ok) throw new Error(`Failed: ${res.status}`)
+      await fetchData()
+    } catch (err) {
+      console.error("Failed to delete equipment", err)
+    }
+  }
+
   return (
     <div className="container mx-auto py-8 px-4">
       <h1 className="text-3xl font-bold mb-2">Super Admin Dashboard</h1>
@@ -563,7 +576,7 @@ export default function SuperAdminDashboardPage() {
                         >
                           <Users className="h-4 w-4" />
                         </Button>
-                        <Button variant="outline" size="sm">
+                        <Button variant="outline" size="sm" onClick={() => handleDeleteEquipment(equipment.id)}>
                           <Trash2 className="h-4 w-4 text-red-500" />
                         </Button>
                       </div>


### PR DESCRIPTION
## Summary
- add API route to handle operations on equipment by id, including deleting
- confirm before deleting equipment via dashboard
- wire up delete button in super admin dashboard

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails: blocked fetching fonts from fonts.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_6857d8327104832fa050bd213892f4b3