### PR TITLE
Fix super admin access and fetch

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -27,6 +27,7 @@ export async function middleware(request: NextRequest) {
       "GET,POST,PUT,DELETE,OPTIONS"
     );
     res.headers.set("Access-Control-Allow-Headers", "*");
+    res.headers.set("Access-Control-Allow-Credentials", "true");
 
     // Role checks for protected APIs
     if (pathname.startsWith("/api/admin")) {


### PR DESCRIPTION
## Summary
- enforce super-admin check on dashboard
- include credentials in dashboard API calls
- allow credentials in CORS middleware

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6857e1f78d9c832fbb24312936e48010